### PR TITLE
Remove port from cronjob url

### DIFF
--- a/helm_deploy/offender-assessments-events/templates/cronjob.yaml
+++ b/helm_deploy/offender-assessments-events/templates/cronjob.yaml
@@ -29,6 +29,6 @@ spec:
             args:
             - /bin/sh
             - -c
-            - curl {{ template "app.fullname" . }}:{{ .Values.image.port }}/events
+            - curl {{ template "app.fullname" . }}/events
           restartPolicy: OnFailure
 {{- end }}


### PR DESCRIPTION
Cronjob is hitting service, thus it should hit port 80 rather than the container port